### PR TITLE
Fix all linting errors

### DIFF
--- a/open-dupr-react/src/components/player/MatchDetailsModal.tsx
+++ b/open-dupr-react/src/components/player/MatchDetailsModal.tsx
@@ -4,43 +4,7 @@ import Avatar from "@/components/ui/avatar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useNavigate } from "react-router-dom";
 import { X } from "lucide-react";
-
-type PlayerRef = {
-  id?: number;
-  fullName: string;
-  imageUrl?: string;
-  rating?: string;
-  preRating?: string;
-  postRating?: string;
-};
-
-type MatchTeam = {
-  id?: number;
-  serial?: number;
-  player1: PlayerRef;
-  player2?: PlayerRef | null;
-  winner?: boolean;
-  delta?: string;
-  teamRating?: string;
-  game1?: number;
-  game2?: number;
-  game3?: number;
-  game4?: number;
-  game5?: number;
-};
-
-type Match = {
-  id: number;
-  venue?: string;
-  location?: string;
-  tournament?: string;
-  eventDate?: string;
-  eventFormat?: string;
-  teams: MatchTeam[];
-  noOfGames?: number;
-  confirmed?: boolean;
-  status?: string;
-};
+import { Match, MatchTeam, PlayerRef } from "./MatchCard";
 
 function getDisplayName(fullName: string) {
   const cleaned = fullName.trim().replace(/\s+/g, " ");
@@ -62,7 +26,7 @@ function extractImpactDelta(
   playerIndex: 1 | 2,
   eventFormat?: string
 ): number | null {
-  const impact = (team as any).preMatchRatingAndImpact || {};
+  const impact = team.preMatchRatingAndImpact || {};
   const keysToTry: string[] = [];
   if (eventFormat === "DOUBLES") {
     keysToTry.push(
@@ -90,7 +54,7 @@ function extractImpactDelta(
   );
 
   for (const key of keysToTry) {
-    const val = toNumber(impact?.[key] as any);
+    const val = toNumber(impact?.[key]);
     if (val !== null) return val;
   }
   return null;
@@ -100,7 +64,7 @@ function getPostMatchRating(
   player: PlayerRef,
   eventFormat?: string
 ): number | null {
-  const pmr: any = (player as any).postMatchRating;
+  const pmr = player.postMatchRating;
   if (pmr && typeof pmr === "object") {
     if (eventFormat === "DOUBLES" && pmr.doubles != null)
       return toNumber(pmr.doubles);
@@ -110,7 +74,7 @@ function getPostMatchRating(
     if (pmr.doubles != null) return toNumber(pmr.doubles);
     if (pmr.singles != null) return toNumber(pmr.singles);
   }
-  return toNumber((player as any).postRating ?? player.rating);
+  return toNumber(player.postRating ?? player.rating);
 }
 
 function getPreMatchRating(
@@ -119,7 +83,7 @@ function getPreMatchRating(
   eventFormat?: string,
   player?: PlayerRef
 ): number | null {
-  const pri: any = (team as any).preMatchRatingAndImpact;
+  const pri = team.preMatchRatingAndImpact;
   if (pri && typeof pri === "object") {
     const preKey =
       eventFormat === "DOUBLES"
@@ -144,9 +108,7 @@ function getPreMatchRating(
     }
   }
   if (player) {
-    const pre = toNumber(
-      (player as any).preMatchRating ?? (player as any).preRating
-    );
+    const pre = toNumber(player.preRating);
     if (pre !== null) return pre;
   }
   return null;
@@ -304,8 +266,8 @@ const MatchDetailsModal: React.FC<MatchDetailsModalProps> = ({
   // Build game chips prominently
   const games = [1, 2, 3, 4, 5]
     .map((i) => {
-      const l = (teamA as any)[`game${i}`] as number | undefined;
-      const r = (teamB as any)[`game${i}`] as number | undefined;
+      const l = teamA[`game${i}` as keyof MatchTeam] as number | undefined;
+      const r = teamB[`game${i}` as keyof MatchTeam] as number | undefined;
       if (typeof l === "number" && l >= 0 && typeof r === "number" && r >= 0) {
         return { l, r };
       }

--- a/open-dupr-react/src/components/player/MatchHistory.tsx
+++ b/open-dupr-react/src/components/player/MatchHistory.tsx
@@ -1,26 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { getOtherUserMatchHistory } from "@/lib/api";
-import MatchCard from "@/components/player/MatchCard";
+import MatchCard, { Match } from "@/components/player/MatchCard";
 
 interface MatchHistoryProps {
   playerId?: number;
 }
 
-interface MatchData {
-  id: number;
-  venue: string;
-  eventDate: string;
-  eventFormat: string;
-  teams: Array<{
-    player1: { fullName: string; rating: string };
-    player2?: { fullName: string; rating: string };
-    winner: boolean;
-    delta: string;
-  }>;
-}
-
 const MatchHistory: React.FC<MatchHistoryProps> = ({ playerId }) => {
-  const [matches, setMatches] = useState<MatchData[]>([]);
+  const [matches, setMatches] = useState<Match[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -68,7 +55,7 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({ playerId }) => {
           {matches.slice(0, 5).map((match) => (
             <MatchCard
               key={match.id}
-              match={match as any}
+              match={match}
               currentUserId={playerId}
             />
           ))}

--- a/open-dupr-react/src/components/player/PlayerRatings.tsx
+++ b/open-dupr-react/src/components/player/PlayerRatings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 interface PlayerRatingsProps {
   singles?: string | number | null;


### PR DESCRIPTION
Refactored TypeScript types to improve type safety and reduce code duplication.

- Centralized `PlayerRef`, `MatchTeam`, and `Match` types in `MatchCard.tsx`, exported them, and imported them in other components.
- Removed many `any` type assertions and corrected state and prop types throughout the related components.
- Removed an unused import in `PlayerRatings.tsx`.
- These changes fix all the linting errors reported by `eslint`.