### PR TITLE
feat: Add GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./open-dupr-react
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install
+      - name: Run linter
+        run: bun run lint
+
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./open-dupr-react
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install
+      - name: Build project
+        run: bun run build


### PR DESCRIPTION
Adds a new GitHub Actions workflow to run lint and build checks on every push and pull request to the main branch.

The workflow defines two jobs, 'lint' and 'build', that run in parallel.
- The 'lint' job runs 'bun run lint'.
- The 'build' job runs 'bun run build'.

Both jobs are configured to run within the 'open-dupr-react' directory.