### PR TITLE
Fix duplicate match details addresses

### DIFF
--- a/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
+++ b/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
@@ -419,16 +419,9 @@ const MatchDetailsPage: React.FC = () => {
             </div>
             {match.venue && (
               <div className="text-sm text-muted-foreground">
-                {(() => {
-                  const venue = match.venue?.trim();
-                  const location = match.location?.trim();
-                  console.log('Venue:', venue);
-                  console.log('Location:', location);
-                  console.log('Are they equal?', venue === location);
-                  return location && location !== venue
-                    ? `${venue} • ${location}`
-                    : venue;
-                })()}
+                {match.location && match.location.trim() !== match.venue.trim()
+                  ? `${match.venue} • ${match.location}`
+                  : match.venue}
               </div>
             )}
             <div className="text-sm text-muted-foreground">

--- a/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
+++ b/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
@@ -408,9 +408,9 @@ const MatchDetailsPage: React.FC = () => {
         <CardHeader className="px-6 pt-6 pb-4">
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              {(match.eventName || match.venue) && (
+              {match.eventName && (
                 <CardTitle className="text-xl">
-                  {match.eventName || match.venue}
+                  {match.eventName}
                 </CardTitle>
               )}
               <div className="text-sm text-muted-foreground font-mono">

--- a/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
+++ b/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
@@ -419,7 +419,7 @@ const MatchDetailsPage: React.FC = () => {
             </div>
             {match.venue && (
               <div className="text-sm text-muted-foreground">
-                {match.location
+                {match.location && match.location !== match.venue
                   ? `${match.venue} • ${match.location}`
                   : match.venue}
               </div>

--- a/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
+++ b/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
@@ -419,9 +419,16 @@ const MatchDetailsPage: React.FC = () => {
             </div>
             {match.venue && (
               <div className="text-sm text-muted-foreground">
-                {match.location && match.location !== match.venue
-                  ? `${match.venue} • ${match.location}`
-                  : match.venue}
+                {(() => {
+                  const venue = match.venue?.trim();
+                  const location = match.location?.trim();
+                  console.log('Venue:', venue);
+                  console.log('Location:', location);
+                  console.log('Are they equal?', venue === location);
+                  return location && location !== venue
+                    ? `${venue} • ${location}`
+                    : venue;
+                })()}
               </div>
             )}
             <div className="text-sm text-muted-foreground">

--- a/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
+++ b/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
@@ -407,16 +407,11 @@ const MatchDetailsPage: React.FC = () => {
       <Card className="rounded-xl">
         <CardHeader className="px-6 pt-6 pb-4">
           <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              {match.eventName && (
-                <CardTitle className="text-xl">
-                  {match.eventName}
-                </CardTitle>
-              )}
-              <div className="text-sm text-muted-foreground font-mono">
-                ID: {match.id}
-              </div>
-            </div>
+            {match.eventName && (
+              <CardTitle className="text-xl">
+                {match.eventName}
+              </CardTitle>
+            )}
             {match.venue && (
               <div className="text-sm text-muted-foreground">
                 {match.location && match.location.trim() !== match.venue.trim()
@@ -520,6 +515,12 @@ const MatchDetailsPage: React.FC = () => {
               </div>
             </div>
           )}
+
+          <div className="mt-6 pt-4 border-t">
+            <div className="text-xs text-muted-foreground font-mono text-center">
+              Match ID: {match.id}
+            </div>
+          </div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
Remove venue fallback from the match details title to prevent duplicate display of location information.

The title previously displayed `match.eventName || match.venue`. If `match.eventName` was absent, `match.venue` was shown in the title, leading to duplication since `match.venue` is also displayed in a separate location section below. This change ensures the venue is only shown once.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c00fc77-c258-49fa-ac7d-b53df76923fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c00fc77-c258-49fa-ac7d-b53df76923fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

