### PR TITLE
Make full match page elements clickable

### DIFF
--- a/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
+++ b/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
@@ -428,7 +428,7 @@ const MatchDetailsPage: React.FC = () => {
         <CardContent className="px-6 pb-6">
           <div className="grid gap-6 md:grid-cols-[1fr_auto_1fr] md:items-center md:gap-8">
             <div className="justify-self-start">
-              <TeamHeader team={teamA} />
+              <TeamHeader team={teamA} onClickPlayer={handleClickPlayer} />
             </div>
             <div className="flex flex-col items-center justify-center gap-2">
               <MatchScoreDisplay
@@ -438,7 +438,7 @@ const MatchDetailsPage: React.FC = () => {
               />
             </div>
             <div className="justify-self-end">
-              <TeamHeader team={teamB} />
+              <TeamHeader team={teamB} onClickPlayer={handleClickPlayer} />
             </div>
           </div>
 

--- a/open-dupr-react/src/components/player/shared/MatchDisplay.tsx
+++ b/open-dupr-react/src/components/player/shared/MatchDisplay.tsx
@@ -5,33 +5,73 @@ import {
   getScoreClasses,
 } from "./match-utils";
 
-export function TeamHeader({ team }: { team: MatchTeam }) {
+interface TeamHeaderProps {
+  team: MatchTeam;
+  onClickPlayer?: (id?: number) => void;
+}
+
+export function TeamHeader({ team, onClickPlayer }: TeamHeaderProps) {
   const isDoubles = Boolean(team.player2);
+
+  const handlePlayerClick = (e: React.MouseEvent, playerId?: number) => {
+    e.stopPropagation();
+    if (onClickPlayer && playerId) {
+      onClickPlayer(playerId);
+    }
+  };
+
   return (
     <div className="flex items-center gap-2 min-w-0">
       <div className="flex -space-x-2">
-        <Avatar
-          name={team.player1.fullName}
-          src={team.player1.imageUrl}
-          size="sm"
-          className="ring-2 ring-background"
-        />
-        {isDoubles && (
+        <button
+          type="button"
+          onClick={(e) => handlePlayerClick(e, team.player1.id)}
+          className="hover:ring-2 hover:ring-primary/20 transition-all"
+          disabled={!onClickPlayer}
+        >
           <Avatar
-            name={team.player2!.fullName}
-            src={team.player2!.imageUrl}
+            name={team.player1.fullName}
+            src={team.player1.imageUrl}
             size="sm"
             className="ring-2 ring-background"
           />
+        </button>
+        {isDoubles && (
+          <button
+            type="button"
+            onClick={(e) => handlePlayerClick(e, team.player2!.id)}
+            className="hover:ring-2 hover:ring-primary/20 transition-all"
+            disabled={!onClickPlayer}
+          >
+            <Avatar
+              name={team.player2!.fullName}
+              src={team.player2!.imageUrl}
+              size="sm"
+              className="ring-2 ring-background"
+            />
+          </button>
         )}
       </div>
       <div className="min-w-0">
-        <div className="truncate text-sm font-medium">
-          {isDoubles
-            ? `${getDisplayName(team.player1.fullName)} & ${getDisplayName(
-                team.player2!.fullName
-              )}`
-            : getDisplayName(team.player1.fullName)}
+        <div className="flex flex-col gap-1">
+          <button
+            type="button"
+            onClick={(e) => handlePlayerClick(e, team.player1.id)}
+            className="font-medium truncate text-left hover:underline hover:text-primary transition-colors text-sm"
+            disabled={!onClickPlayer}
+          >
+            {getDisplayName(team.player1.fullName)}
+          </button>
+          {isDoubles && (
+            <button
+              type="button"
+              onClick={(e) => handlePlayerClick(e, team.player2!.id)}
+              className="font-medium truncate text-left hover:underline hover:text-primary transition-colors text-sm"
+              disabled={!onClickPlayer}
+            >
+              {getDisplayName(team.player2!.fullName)}
+            </button>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Make player profile pictures and names clickable on the full match page to ensure consistent navigation with the basic match view.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbbc5655-70cc-468a-914c-0f63c302b18a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbbc5655-70cc-468a-914c-0f63c302b18a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

