### PR TITLE
Fix ios pwa header status bar overlap

### DIFF
--- a/open-dupr-react/src/components/AppHeader.tsx
+++ b/open-dupr-react/src/components/AppHeader.tsx
@@ -70,7 +70,7 @@ const AppHeader: React.FC = () => {
   };
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 relative">
+    <header className="sticky top-0 z-50 w-full border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 relative safe-area-inset-top">
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
         {showBackButton ? (
           <Button


### PR DESCRIPTION
Add `safe-area-inset-top` to the header to fix overlap with the iOS PWA status bar when scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-279c3097-937c-4c0a-af38-3a007d136745">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-279c3097-937c-4c0a-af38-3a007d136745">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

