### PR TITLE
Disable text selection on add match

### DIFF
--- a/open-dupr-react/src/components/pages/RecordMatchPage.tsx
+++ b/open-dupr-react/src/components/pages/RecordMatchPage.tsx
@@ -1005,7 +1005,7 @@ const RecordMatchPage: React.FC = () => {
                   onChange={setMyScore}
                   layout="horizontal"
                 />
-                <div className="text-xl sm:text-2xl font-bold text-gray-400">
+                <div className="text-xl sm:text-2xl font-bold text-gray-400 select-none">
                   VS
                 </div>
                 <ScoreInput
@@ -1072,7 +1072,7 @@ const RecordMatchPage: React.FC = () => {
                     onChange={setMyScore}
                     layout="vertical"
                   />
-                  <div className="text-4xl font-bold text-gray-400">VS</div>
+                  <div className="text-4xl font-bold text-gray-400 select-none">VS</div>
                   <ScoreInput
                     value={opponentScore}
                     onChange={setOpponentScore}


### PR DESCRIPTION
Add `select-none` class to "VS" text to prevent it from being selectable.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fd6c38e-07d4-4fc2-8b0a-7df2055a78b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fd6c38e-07d4-4fc2-8b0a-7df2055a78b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

