### PR TITLE
Fix add teammate pwa safe area

### DIFF
--- a/open-dupr-react/src/components/pages/RecordMatchPage.tsx
+++ b/open-dupr-react/src/components/pages/RecordMatchPage.tsx
@@ -308,7 +308,7 @@ const PlayerSlot: React.FC<PlayerSlotProps> = ({
 
       {/* Player Selection Modal */}
       {showModal && (
-        <div className="fixed inset-0 bg-white z-50">
+        <div className="fixed inset-0 bg-white z-50 safe-area-inset-top">
           {/* Header */}
           <div className="p-6 border-b border-gray-100">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
Add `safe-area-inset-top` class to the Add Teammate modal to respect the safe area at the top of the screen when used as a PWA.

---
<a href="https://cursor.com/background-agent?bcId=bc-79050198-8c3c-403d-bdf6-90b689f3a5ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79050198-8c3c-403d-bdf6-90b689f3a5ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

