### PR TITLE
Redesign match stats and cards for cleaner look

### DIFF
--- a/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
+++ b/open-dupr-react/src/components/pages/MatchDetailsPage.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import Avatar from "@/components/ui/avatar";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, CheckCircle, XCircle } from "lucide-react";
 import {
@@ -165,7 +164,7 @@ function TeamBlock({
             key={p.id ?? p.fullName}
             type="button"
             onClick={() => onClickPlayer(p.id)}
-            className="group flex items-center justify-between gap-3 rounded-md border p-2 text-left hover:bg-accent"
+            className="group flex items-center justify-between gap-3 rounded-lg border p-3 text-left hover:bg-muted/50 transition-colors"
           >
             <span className="flex items-center gap-3 min-w-0">
               <Avatar
@@ -404,28 +403,26 @@ const MatchDetailsPage: React.FC = () => {
 
   return (
     <div className="container mx-auto p-4 max-w-4xl">
-      <Card className="rounded-xl">
-        <CardHeader className="px-6 pt-6 pb-4">
-          <div className="space-y-2">
-            {match.eventName && (
-              <CardTitle className="text-xl">
-                {match.eventName}
-              </CardTitle>
-            )}
-            {match.venue && (
-              <div className="text-sm text-muted-foreground">
-                {match.location && match.location.trim() !== match.venue.trim()
-                  ? `${match.venue} • ${match.location}`
-                  : match.venue}
-              </div>
-            )}
+      <div className="space-y-6">
+        <div className="space-y-2">
+          {match.eventName && (
+            <h1 className="text-2xl font-semibold">
+              {match.eventName}
+            </h1>
+          )}
+          {match.venue && (
             <div className="text-sm text-muted-foreground">
-              {match.eventDate}
-              {match.tournament ? ` • ${match.tournament}` : ""}
+              {match.location && match.location.trim() !== match.venue.trim()
+                ? `${match.venue} • ${match.location}`
+                : match.venue}
             </div>
+          )}
+          <div className="text-sm text-muted-foreground">
+            {match.eventDate}
+            {match.tournament ? ` • ${match.tournament}` : ""}
           </div>
-        </CardHeader>
-        <CardContent className="px-6 pb-6">
+        </div>
+        <div>
           <div className="grid gap-6 md:grid-cols-[1fr_auto_1fr] md:items-center md:gap-8">
             <div className="justify-self-start">
               <TeamHeader team={teamA} onClickPlayer={handleClickPlayer} />
@@ -442,7 +439,7 @@ const MatchDetailsPage: React.FC = () => {
             </div>
           </div>
 
-          <div className="mt-6 grid gap-6 md:grid-cols-2">
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
             <TeamBlock
               team={teamA}
               onClickPlayer={handleClickPlayer}
@@ -456,7 +453,7 @@ const MatchDetailsPage: React.FC = () => {
           </div>
 
           {!match.confirmed && (
-            <div className="mt-6 pt-6 border-t">
+            <div className="mt-8 pt-6 border-t">
               <h3 className="text-sm font-medium text-muted-foreground mb-3">
                 Awaiting Validation From
               </h3>
@@ -469,7 +466,7 @@ const MatchDetailsPage: React.FC = () => {
                         key={p!.id}
                         type="button"
                         onClick={() => handleClickPlayer(p!.id)}
-                        className="flex items-center gap-3 p-3 rounded-md border w-full text-left hover:bg-accent transition-colors"
+                        className="flex items-center gap-3 p-3 rounded-lg border w-full text-left hover:bg-muted/50 transition-colors"
                       >
                         <Avatar
                           name={p!.fullName}
@@ -487,7 +484,7 @@ const MatchDetailsPage: React.FC = () => {
           )}
 
           {needsValidation && (
-            <div className="mt-6 pt-6 border-t">
+            <div className="mt-8 pt-6 border-t">
               <h3 className="text-sm font-medium text-muted-foreground mb-4">
                 Action Required
               </h3>
@@ -516,13 +513,13 @@ const MatchDetailsPage: React.FC = () => {
             </div>
           )}
 
-          <div className="mt-6 pt-4 border-t">
+          <div className="mt-8 pt-4 border-t">
             <div className="text-xs text-muted-foreground font-mono text-center">
               Match ID: {match.id}
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </div>
     </div>
   );
 };

--- a/open-dupr-react/src/components/player/MatchCard.tsx
+++ b/open-dupr-react/src/components/player/MatchCard.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Avatar from "@/components/ui/avatar";
-import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CheckCircle, XCircle, ChevronUp, ChevronDown } from "lucide-react";
 import { confirmMatch, rejectMatch } from "@/lib/api";
@@ -154,8 +153,8 @@ const MatchCard: React.FC<MatchCardProps> = ({
   };
 
   return (
-    <Card
-      className="p-4 cursor-pointer transition hover:bg-accent/40"
+    <div
+      className="bg-background border rounded-lg p-3 cursor-pointer transition hover:bg-muted/30"
       onClick={() => {
         const path = profileUserId
           ? `/match/${match.id}/player/${profileUserId}`
@@ -186,87 +185,85 @@ const MatchCard: React.FC<MatchCardProps> = ({
         }
       }}
     >
-      <CardContent className="p-0">
-        <div className="flex flex-col gap-3">
-          <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
-            <div className="flex items-center gap-2">
-              {userDelta !== null && (
-                <span className="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 font-mono">
-                  {userDelta >= 0 ? (
-                    <ChevronUp className="h-3 w-3 text-emerald-600" />
-                  ) : (
-                    <ChevronDown className="h-3 w-3 text-rose-600" />
-                  )}
-                  <span
-                    className={
-                      userDelta >= 0 ? "text-emerald-700" : "text-rose-700"
-                    }
-                  >
-                    {Math.abs(userDelta).toFixed(3)}
-                  </span>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <div className="flex items-center gap-2">
+            {userDelta !== null && (
+              <span className="inline-flex items-center gap-1 rounded border px-1.5 py-0.5 font-mono text-xs">
+                {userDelta >= 0 ? (
+                  <ChevronUp className="h-3 w-3 text-emerald-600" />
+                ) : (
+                  <ChevronDown className="h-3 w-3 text-rose-600" />
+                )}
+                <span
+                  className={
+                    userDelta >= 0 ? "text-emerald-700" : "text-rose-700"
+                  }
+                >
+                  {Math.abs(userDelta).toFixed(3)}
                 </span>
-              )}
-              {!match.confirmed && (
-                <span className="rounded-full bg-yellow-100 text-yellow-800 px-2 py-0.5 font-medium">
-                  Pending
-                </span>
-              )}
-            </div>
-            <div className="flex items-center gap-2">
-              {match.eventDate && <span>{match.eventDate}</span>}
-            </div>
+              </span>
+            )}
+            {!match.confirmed && (
+              <span className="rounded bg-yellow-100 text-yellow-800 px-1.5 py-0.5 text-xs font-medium">
+                Pending
+              </span>
+            )}
           </div>
-          <div className="flex flex-col gap-3 md:grid md:grid-cols-[1fr_auto_1fr] md:items-center">
-            <div
-              className={`${
-                teamAWon ? "text-emerald-700" : "text-rose-700"
-              } min-w-0 md:justify-self-start`}
-            >
-              <TeamStack team={teamA} />
-            </div>
-            <div className="flex flex-col items-center justify-center gap-1">
-              <MatchScoreDisplay
-                games={gamePairs}
-                currentUserId={currentUserId}
-                size="small"
-              />
-            </div>
-            <div
-              className={`${
-                teamBWon ? "text-emerald-700" : "text-rose-700"
-              } min-w-0 self-end md:justify-self-end`}
-            >
-              <TeamStack team={teamB} />
-            </div>
+          <div className="flex items-center gap-2">
+            {match.eventDate && <span>{match.eventDate}</span>}
           </div>
-
-          {needsValidation && (
-            <div className="flex gap-2 mt-4 pt-4 border-t">
-              <Button
-                variant="outline"
-                size="sm"
-                className="flex-1 text-green-600 hover:text-green-700 hover:bg-green-50"
-                onClick={handleConfirm}
-                disabled={isProcessing}
-              >
-                <CheckCircle className="h-4 w-4 mr-2" />
-                {isProcessing ? "Validating..." : "Validate"}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="flex-1 text-red-600 hover:text-red-700 hover:bg-red-50"
-                onClick={handleReject}
-                disabled={isProcessing}
-              >
-                <XCircle className="h-4 w-4 mr-2" />
-                {isProcessing ? "Rejecting..." : "Reject"}
-              </Button>
-            </div>
-          )}
         </div>
-      </CardContent>
-    </Card>
+        <div className="flex flex-col gap-2 md:grid md:grid-cols-[1fr_auto_1fr] md:items-center">
+          <div
+            className={`${
+              teamAWon ? "text-emerald-700" : "text-rose-700"
+            } min-w-0 md:justify-self-start`}
+          >
+            <TeamStack team={teamA} />
+          </div>
+          <div className="flex flex-col items-center justify-center">
+            <MatchScoreDisplay
+              games={gamePairs}
+              currentUserId={currentUserId}
+              size="small"
+            />
+          </div>
+          <div
+            className={`${
+              teamBWon ? "text-emerald-700" : "text-rose-700"
+            } min-w-0 self-end md:justify-self-end`}
+          >
+            <TeamStack team={teamB} />
+          </div>
+        </div>
+
+        {needsValidation && (
+          <div className="flex gap-2 mt-3 pt-3 border-t">
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-1 text-green-600 hover:text-green-700 hover:bg-green-50"
+              onClick={handleConfirm}
+              disabled={isProcessing}
+            >
+              <CheckCircle className="h-4 w-4 mr-2" />
+              {isProcessing ? "Validating..." : "Validate"}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-1 text-red-600 hover:text-red-700 hover:bg-red-50"
+              onClick={handleReject}
+              disabled={isProcessing}
+            >
+              <XCircle className="h-4 w-4 mr-2" />
+              {isProcessing ? "Rejecting..." : "Reject"}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/open-dupr-react/src/components/player/PlayerStatsRatings.tsx
+++ b/open-dupr-react/src/components/player/PlayerStatsRatings.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { ChevronDown, Info } from "lucide-react";
 import { getOtherUserStats } from "@/lib/api";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import ReliabilityModal from "@/components/ui/reliability-modal";
 import { PlayerStatsSkeleton } from "@/components/ui/loading-skeletons";
@@ -83,22 +82,20 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
 
   if (!playerId) {
     return (
-      <Card className="py-4">
-        <CardHeader className="pb-1 px-4">
-          <div className="text-center">
-            <div className="grid grid-cols-2 gap-4 mt-2">
-              <div>
-                <p className="text-2xl font-bold">-</p>
-                <p className="text-xs text-muted-foreground">Singles</p>
-              </div>
-              <div>
-                <p className="text-2xl font-bold">-</p>
-                <p className="text-xs text-muted-foreground">Doubles</p>
-              </div>
+      <div className="bg-background border rounded-lg p-4">
+        <div className="text-center">
+          <div className="grid grid-cols-2 gap-6">
+            <div>
+              <p className="text-2xl font-semibold text-muted-foreground">-</p>
+              <p className="text-sm text-muted-foreground mt-1">Singles</p>
+            </div>
+            <div>
+              <p className="text-2xl font-semibold text-muted-foreground">-</p>
+              <p className="text-sm text-muted-foreground mt-1">Doubles</p>
             </div>
           </div>
-        </CardHeader>
-      </Card>
+        </div>
+      </div>
     );
   }
 
@@ -108,35 +105,31 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
 
   if (error) {
     return (
-      <Card className="py-4">
-        <CardHeader className="pb-1 px-4">
-          <div className="text-center">
-            <div className="grid grid-cols-2 gap-4 mt-2">
-              <div>
-                <p className="text-2xl font-bold">{formatRating(singles)}</p>
-                <p className="text-xs text-muted-foreground">Singles</p>
-                {singlesReliabilityScore != null && (
-                  <p className="text-xs text-green-600 font-medium">
-                    {formatReliability(singlesReliabilityScore)}
-                  </p>
-                )}
-              </div>
-              <div>
-                <p className="text-2xl font-bold">{formatRating(doubles)}</p>
-                <p className="text-xs text-muted-foreground">Doubles</p>
-                {doublesReliabilityScore != null && (
-                  <p className="text-xs text-green-600 font-medium">
-                    {formatReliability(doublesReliabilityScore)}
-                  </p>
-                )}
-              </div>
+      <div className="bg-background border rounded-lg p-4">
+        <div className="text-center">
+          <div className="grid grid-cols-2 gap-6">
+            <div>
+              <p className="text-2xl font-semibold">{formatRating(singles)}</p>
+              <p className="text-sm text-muted-foreground mt-1">Singles</p>
+              {singlesReliabilityScore != null && (
+                <p className="text-xs text-green-600 font-medium mt-1">
+                  {formatReliability(singlesReliabilityScore)}
+                </p>
+              )}
+            </div>
+            <div>
+              <p className="text-2xl font-semibold">{formatRating(doubles)}</p>
+              <p className="text-sm text-muted-foreground mt-1">Doubles</p>
+              {doublesReliabilityScore != null && (
+                <p className="text-xs text-green-600 font-medium mt-1">
+                  {formatReliability(doublesReliabilityScore)}
+                </p>
+              )}
             </div>
           </div>
-        </CardHeader>
-        <CardContent className="pt-0 px-4">
-          <p className="text-red-500 text-sm text-center">{error}</p>
-        </CardContent>
-      </Card>
+        </div>
+        <p className="text-red-500 text-sm text-center mt-3">{error}</p>
+      </div>
     );
   }
 
@@ -148,62 +141,60 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
         reliabilityPercentage={currentReliabilityScore}
       />
 
-      <Card className="py-4">
-        <CardHeader className="pb-1 px-4">
-          <div className="text-center lg:text-left">
-            <div className="grid grid-cols-2 gap-4 mt-2 lg:mt-0 lg:max-w-xs">
-              <div>
-                <p className="text-2xl font-bold">{formatRating(singles)}</p>
-                <p className="text-xs text-muted-foreground">Singles</p>
-                {singlesReliabilityScore != null && (
-                  <div className="flex items-center justify-center lg:justify-start gap-1">
-                    <p className="text-xs text-green-600 font-medium">
-                      {formatReliability(singlesReliabilityScore)}
-                    </p>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() =>
-                        openReliabilityModal(singlesReliabilityScore)
-                      }
-                      className="h-4 w-4 p-0 text-green-600 hover:text-green-800"
-                    >
-                      <Info className="h-3 w-3" />
-                    </Button>
-                  </div>
-                )}
-              </div>
-              <div className="lg:justify-self-end">
-                <p className="text-2xl font-bold">{formatRating(doubles)}</p>
-                <p className="text-xs text-muted-foreground">Doubles</p>
-                {doublesReliabilityScore != null && (
-                  <div className="flex items-center justify-center lg:justify-start gap-1">
-                    <p className="text-xs text-green-600 font-medium">
-                      {formatReliability(doublesReliabilityScore)}
-                    </p>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() =>
-                        openReliabilityModal(doublesReliabilityScore)
-                      }
-                      className="h-4 w-4 p-0 text-green-600 hover:text-green-800"
-                    >
-                      <Info className="h-3 w-3" />
-                    </Button>
-                  </div>
-                )}
-              </div>
+      <div className="bg-background border rounded-lg p-4">
+        <div className="text-center lg:text-left">
+          <div className="grid grid-cols-2 gap-6 lg:max-w-xs">
+            <div>
+              <p className="text-2xl font-semibold">{formatRating(singles)}</p>
+              <p className="text-sm text-muted-foreground mt-1">Singles</p>
+              {singlesReliabilityScore != null && (
+                <div className="flex items-center justify-center lg:justify-start gap-1 mt-1">
+                  <p className="text-xs text-green-600 font-medium">
+                    {formatReliability(singlesReliabilityScore)}
+                  </p>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      openReliabilityModal(singlesReliabilityScore)
+                    }
+                    className="h-4 w-4 p-0 text-green-600 hover:text-green-800"
+                  >
+                    <Info className="h-3 w-3" />
+                  </Button>
+                </div>
+              )}
+            </div>
+            <div className="lg:justify-self-end">
+              <p className="text-2xl font-semibold">{formatRating(doubles)}</p>
+              <p className="text-sm text-muted-foreground mt-1">Doubles</p>
+              {doublesReliabilityScore != null && (
+                <div className="flex items-center justify-center lg:justify-start gap-1 mt-1">
+                  <p className="text-xs text-green-600 font-medium">
+                    {formatReliability(doublesReliabilityScore)}
+                  </p>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      openReliabilityModal(doublesReliabilityScore)
+                    }
+                    className="h-4 w-4 p-0 text-green-600 hover:text-green-800"
+                  >
+                    <Info className="h-3 w-3" />
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
-        </CardHeader>
+        </div>
 
         {stats && (
-          <CardContent className="-mt-2 pt-0 px-4">
+          <div className="mt-4 pt-4 border-t">
             <button
               type="button"
               onClick={() => setExpanded((prev) => !prev)}
-              className="w-full flex items-center justify-between py-0.5 hover:bg-gray-50 rounded px-2 -mx-2 -mt-1 transition-colors"
+              className="w-full flex items-center justify-between py-2 hover:bg-muted/50 rounded px-2 -mx-2 transition-colors"
               aria-expanded={expanded}
             >
               <div className="flex items-center gap-2">
@@ -225,33 +216,33 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
             </button>
 
             {expanded && (
-              <div className="mt-1 space-y-1.5 border-t pt-1.5">
-                <div className="grid grid-cols-3 gap-2 text-center">
-                  <div className="bg-green-50 p-2 rounded-lg">
-                    <div className="text-base font-bold text-green-600">
+              <div className="mt-3 space-y-3">
+                <div className="grid grid-cols-3 gap-3 text-center">
+                  <div className="bg-green-50 p-3 rounded-lg">
+                    <div className="text-lg font-semibold text-green-600">
                       {stats.resulOverview.wins}
                     </div>
                     <div className="text-xs text-muted-foreground">Wins</div>
                   </div>
-                  <div className="bg-red-50 p-2 rounded-lg">
-                    <div className="text-base font-bold text-red-600">
+                  <div className="bg-red-50 p-3 rounded-lg">
+                    <div className="text-lg font-semibold text-red-600">
                       {stats.resulOverview.losses}
                     </div>
                     <div className="text-xs text-muted-foreground">Losses</div>
                   </div>
-                  <div className="bg-gray-50 p-2 rounded-lg">
-                    <div className="text-base font-bold text-gray-600">
+                  <div className="bg-muted/50 p-3 rounded-lg">
+                    <div className="text-lg font-semibold text-muted-foreground">
                       {stats.resulOverview.pending}
                     </div>
                     <div className="text-xs text-muted-foreground">Pending</div>
                   </div>
                 </div>
 
-                <div className="space-y-2">
+                <div className="space-y-3">
                   <div>
-                    <h4 className="text-sm font-medium mb-1">Singles</h4>
-                    <div className="grid grid-cols-2 gap-2 text-xs">
-                      <div className="bg-gray-50 p-1 rounded">
+                    <h4 className="text-sm font-medium mb-2">Singles</h4>
+                    <div className="grid grid-cols-2 gap-3 text-xs">
+                      <div className="bg-muted/30 p-2 rounded">
                         <div className="text-muted-foreground">Avg Partner</div>
                         <div className="font-mono font-medium">
                           {toDecimalString(
@@ -260,7 +251,7 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
                           )}
                         </div>
                       </div>
-                      <div className="bg-gray-50 p-1 rounded">
+                      <div className="bg-muted/30 p-2 rounded">
                         <div className="text-muted-foreground">
                           Avg Opponent
                         </div>
@@ -275,9 +266,9 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
                   </div>
 
                   <div>
-                    <h4 className="text-sm font-medium mb-1">Doubles</h4>
-                    <div className="grid grid-cols-2 gap-2 text-xs">
-                      <div className="bg-gray-50 p-1 rounded">
+                    <h4 className="text-sm font-medium mb-2">Doubles</h4>
+                    <div className="grid grid-cols-2 gap-3 text-xs">
+                      <div className="bg-muted/30 p-2 rounded">
                         <div className="text-muted-foreground">Avg Partner</div>
                         <div className="font-mono font-medium">
                           {toDecimalString(
@@ -286,7 +277,7 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
                           )}
                         </div>
                       </div>
-                      <div className="bg-gray-50 p-1 rounded">
+                      <div className="bg-muted/30 p-2 rounded">
                         <div className="text-muted-foreground">
                           Avg Opponent
                         </div>
@@ -302,9 +293,9 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
                 </div>
               </div>
             )}
-          </CardContent>
+          </div>
         )}
-      </Card>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
Modernize stats and match cards, and remove card design from the match details page for a cleaner, more minimal look.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0e2b94a-8484-4fe0-b483-75693aecd839">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0e2b94a-8484-4fe0-b483-75693aecd839">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

