### PR TITLE
Add follower following sort options

### DIFF
--- a/open-dupr-react/src/components/pages/FollowersFollowingPage.tsx
+++ b/open-dupr-react/src/components/pages/FollowersFollowingPage.tsx
@@ -507,19 +507,20 @@ const FollowersFollowingPage: React.FC = () => {
                 <option value="singles">Singles Rating</option>
                 <option value="doubles">Doubles Rating</option>
               </select>
-              {sortOption !== "none" && (
-                <button
-                  onClick={toggleSortDirection}
-                  className="p-2 border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                  title={`Sort ${sortDirection === "asc" ? "ascending" : "descending"}`}
-                >
-                  {sortDirection === "asc" ? (
-                    <ArrowUp className="h-4 w-4 text-gray-600" />
-                  ) : (
-                    <ArrowDown className="h-4 w-4 text-gray-600" />
-                  )}
-                </button>
-              )}
+              <button
+                onClick={toggleSortDirection}
+                className={`p-2 border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all ${
+                  sortOption === "none" ? "opacity-0 pointer-events-none" : "opacity-100"
+                }`}
+                title={sortOption !== "none" ? `Sort ${sortDirection === "asc" ? "ascending" : "descending"}` : ""}
+                tabIndex={sortOption === "none" ? -1 : 0}
+              >
+                {sortDirection === "asc" ? (
+                  <ArrowUp className="h-4 w-4 text-gray-600" />
+                ) : (
+                  <ArrowDown className="h-4 w-4 text-gray-600" />
+                )}
+              </button>
             </div>
           </div>
         ) : currentCount !== null && currentCount > 100 ? (


### PR DESCRIPTION
Add sort options (alphabetical, singles/doubles rating) to the follower/following page, limited to lists with 100 or fewer users.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1f4095d-e2d6-40cb-a545-64e2c086e674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d1f4095d-e2d6-40cb-a545-64e2c086e674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

