### PR TITLE
Rearrange sort options and fix button flicker

### DIFF
--- a/open-dupr-react/src/components/pages/FollowersFollowingPage.tsx
+++ b/open-dupr-react/src/components/pages/FollowersFollowingPage.tsx
@@ -497,19 +497,9 @@ const FollowersFollowingPage: React.FC = () => {
         {canSort ? (
           <div className="mb-4 flex justify-end">
             <div className="flex items-center gap-2">
-              <select
-                value={sortOption}
-                onChange={(e) => handleSortOptionChange(e.target.value as SortOption)}
-                className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              >
-                <option value="none">Sort by...</option>
-                <option value="alphabetical">Alphabetical</option>
-                <option value="singles">Singles Rating</option>
-                <option value="doubles">Doubles Rating</option>
-              </select>
               <button
                 onClick={toggleSortDirection}
-                className={`p-2 border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all ${
+                className={`p-2 border border-gray-300 rounded-md hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 transition-colors ${
                   sortOption === "none" ? "opacity-0 pointer-events-none" : "opacity-100"
                 }`}
                 title={sortOption !== "none" ? `Sort ${sortDirection === "asc" ? "ascending" : "descending"}` : ""}
@@ -521,6 +511,16 @@ const FollowersFollowingPage: React.FC = () => {
                   <ArrowDown className="h-4 w-4 text-gray-600" />
                 )}
               </button>
+              <select
+                value={sortOption}
+                onChange={(e) => handleSortOptionChange(e.target.value as SortOption)}
+                className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="none">Sort by...</option>
+                <option value="alphabetical">Alphabetical</option>
+                <option value="singles">Singles Rating</option>
+                <option value="doubles">Doubles Rating</option>
+              </select>
             </div>
           </div>
         ) : currentCount !== null && currentCount > 100 ? (


### PR DESCRIPTION
Swap sort option dropdown and sort direction buttons, and fix button outline flickering caused by conflicting focus styles.

The button outline flickering was due to conflicting `focus:outline-none` and `focus:border-transparent` styles. These were removed, `transition-all` was changed to `transition-colors`, and focus styles were simplified to `focus:ring-2 focus:ring-blue-500` for a smoother, consistent focus indication.

---
<a href="https://cursor.com/background-agent?bcId=bc-9fb9831b-8d3a-4c30-a07d-fe4804542a7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9fb9831b-8d3a-4c30-a07d-fe4804542a7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

