### PR TITLE
Prevent profile flicker on match card click

### DIFF
--- a/open-dupr-react/src/components/player/MatchCard.tsx
+++ b/open-dupr-react/src/components/player/MatchCard.tsx
@@ -22,15 +22,17 @@ interface MatchCardProps {
   onMatchUpdate?: () => void;
 }
 
-function TeamStack({ team }: { team: MatchTeam }) {
+function TeamStack({ team, profileUserId }: { team: MatchTeam; profileUserId?: number }) {
   const navigate = useNavigate();
   const isDoubles = Boolean(team.player2);
 
   const handlePlayerClick = (e: React.MouseEvent, playerId?: number) => {
-    e.stopPropagation();
-    if (playerId) {
-      navigate(`/player/${playerId}`);
+    if (!playerId) return;
+    if (profileUserId && playerId === profileUserId) {
+      return;
     }
+    e.stopPropagation();
+    navigate(`/player/${playerId}`);
   };
 
   return (
@@ -220,7 +222,7 @@ const MatchCard: React.FC<MatchCardProps> = ({
                 teamAWon ? "text-emerald-700" : "text-rose-700"
               } min-w-0 md:justify-self-start`}
             >
-              <TeamStack team={teamA} />
+              <TeamStack team={teamA} profileUserId={profileUserId} />
             </div>
             <div className="flex flex-col items-center justify-center gap-1">
               <MatchScoreDisplay
@@ -234,7 +236,7 @@ const MatchCard: React.FC<MatchCardProps> = ({
                 teamBWon ? "text-emerald-700" : "text-rose-700"
               } min-w-0 self-end md:justify-self-end`}
             >
-              <TeamStack team={teamB} />
+              <TeamStack team={teamB} profileUserId={profileUserId} />
             </div>
           </div>
 


### PR DESCRIPTION
Prevent navigation to the current profile when clicking a player's name/avatar on a match card to avoid page flicker and allow the match card to open.

Clicking the name/avatar of the profile currently being viewed on a match card previously caused a jarring page refresh. This change ensures that if the clicked player is the current profile, navigation is skipped, allowing the `MatchCard`'s primary click handler to open the match details without an unnecessary page reload.

---
<a href="https://cursor.com/background-agent?bcId=bc-4aa78c43-012d-49fc-b434-ce8def6c4c56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4aa78c43-012d-49fc-b434-ce8def6c4c56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

