### PR TITLE
Fix following page follow button logic

### DIFF
--- a/open-dupr-react/src/lib/api.ts
+++ b/open-dupr-react/src/lib/api.ts
@@ -209,12 +209,12 @@ export const getFollowInfo = (feedId: number) =>
 
 export const getFollowers = (feedId: number, offset = 0, limit = 20) =>
   apiFetch(
-    `/activity/v1/user/${feedId}/followers?offset=${offset}&limit=${limit}`
+    `/activity/v1.1/user/${feedId}/followers?offset=${offset}&limit=${limit}`
   );
 
 export const getFollowing = (feedId: number, offset = 0, limit = 20) =>
   apiFetch(
-    `/activity/v1/user/${feedId}/followings?offset=${offset}&limit=${limit}`
+    `/activity/v1.1/user/${feedId}/followings?offset=${offset}&limit=${limit}`
   );
 
 export const followUser = (feedId: number) =>


### PR DESCRIPTION
Update API calls for followings and followers to v1.1 to correctly display follow status.

The previous API version (v1) for `/activity/user/{id}/followings` and `/activity/user/{id}/followers` was returning inconsistent `isFollow` values, leading to "follow" buttons appearing on users already being followed. Updating to v1.1 aligns with the official app's behavior and resolves this issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-ded0c67c-e209-4a72-ad81-f790db355449">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ded0c67c-e209-4a72-ad81-f790db355449">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

