### PR TITLE
Prevent mobile graph touch outline

### DIFF
--- a/open-dupr-react/src/components/player/RatingHistoryChart.tsx
+++ b/open-dupr-react/src/components/player/RatingHistoryChart.tsx
@@ -70,16 +70,18 @@ const RatingHistoryChart: React.FC<RatingHistoryChartProps> = ({ data }) => {
   const pad = (max - min || 1) * 0.1;
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
-      <LineChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 8 }}>
-        <CartesianGrid strokeDasharray="3 3" vertical={false} />
-        <XAxis dataKey="date" tickFormatter={formatDateTick} tick={{ fontSize: 11 }} axisLine={false} tickLine={false} interval="preserveStartEnd" minTickGap={24} />
-        <YAxis domain={[min - pad, max + pad]} tickFormatter={formatYAxisTick} tick={{ fontSize: 11 }} axisLine={false} tickLine={false} width={28} />
-        <Tooltip content={<CustomTooltip />} />
-        <Line type="monotone" dataKey="singles" stroke="#1d4ed8" strokeWidth={2} dot={false} isAnimationActive={false} connectNulls />
-        <Line type="monotone" dataKey="doubles" stroke="#059669" strokeWidth={2} dot={false} isAnimationActive={false} connectNulls />
-      </LineChart>
-    </ResponsiveContainer>
+    <div className="[&_*]:!outline-none [&_*]:select-none touch-manipulation" style={{ WebkitTapHighlightColor: 'transparent' }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" vertical={false} />
+          <XAxis dataKey="date" tickFormatter={formatDateTick} tick={{ fontSize: 11 }} axisLine={false} tickLine={false} interval="preserveStartEnd" minTickGap={24} />
+          <YAxis domain={[min - pad, max + pad]} tickFormatter={formatYAxisTick} tick={{ fontSize: 11 }} axisLine={false} tickLine={false} width={28} />
+          <Tooltip content={<CustomTooltip />} />
+          <Line type="monotone" dataKey="singles" stroke="#1d4ed8" strokeWidth={2} dot={false} isAnimationActive={false} connectNulls />
+          <Line type="monotone" dataKey="doubles" stroke="#059669" strokeWidth={2} dot={false} isAnimationActive={false} connectNulls />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
   );
 };
 


### PR DESCRIPTION
Prevent blue outline on mobile graph touch by adding CSS to disable tap highlight and focus outlines.

The blue outline was caused by browser default focus/active states that appear when users touch interactive elements (like SVG chart components) on mobile devices. This fix adds a wrapper div with `[&_*]:!outline-none`, `[&_*]:select-none`, `touch-manipulation`, and `WebkitTapHighlightColor: 'transparent'` to the `ResponsiveContainer` in `RatingHistoryChart.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a629635-6630-4ace-94fb-ef6df59b5cb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a629635-6630-4ace-94fb-ef6df59b5cb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

