### PR TITLE
Implement dark mode with system preference

### DIFF
--- a/open-dupr-react/src/components/AppHeader.tsx
+++ b/open-dupr-react/src/components/AppHeader.tsx
@@ -12,8 +12,12 @@ import {
   LogOut,
   ArrowLeft,
   Info,
+  Sun,
+  Moon,
+  Monitor,
 } from "lucide-react";
 import { getInitials, getAvatarColor } from "@/lib/avatar-utils";
+import { useTheme } from "@/lib/useTheme";
 
 const AppHeader: React.FC = () => {
   const {
@@ -27,6 +31,7 @@ const AppHeader: React.FC = () => {
   } = useHeader();
   const navigate = useNavigate();
   const { logout: authLogout, token } = useAuth();
+  const { theme, setTheme } = useTheme();
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
 
@@ -67,6 +72,40 @@ const AppHeader: React.FC = () => {
 
   const goToLogin = () => {
     navigate("/login");
+  };
+
+  const getThemeIcon = () => {
+    switch (theme) {
+      case 'light':
+        return <Sun className="h-5 w-5" />;
+      case 'dark':
+        return <Moon className="h-5 w-5" />;
+      case 'system':
+        return <Monitor className="h-5 w-5" />;
+      default:
+        return <Monitor className="h-5 w-5" />;
+    }
+  };
+
+  const getThemeLabel = () => {
+    switch (theme) {
+      case 'light':
+        return 'Light Theme';
+      case 'dark':
+        return 'Dark Theme';
+      case 'system':
+        return 'System Theme';
+      default:
+        return 'System Theme';
+    }
+  };
+
+  const cycleTheme = () => {
+    const themes: Array<'light' | 'dark' | 'system'> = ['system', 'light', 'dark'];
+    const currentIndex = themes.indexOf(theme);
+    const nextIndex = (currentIndex + 1) % themes.length;
+    setTheme(themes[nextIndex]);
+    setOpen(false);
   };
 
   return (
@@ -188,6 +227,14 @@ const AppHeader: React.FC = () => {
                     >
                       <Info className="h-5 w-5" />
                       About Open DUPR
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cycleTheme}
+                      className="w-full px-4 py-3 text-left hover:bg-accent flex items-center gap-2"
+                    >
+                      {getThemeIcon()}
+                      {getThemeLabel()}
                     </button>
                     <div className="my-1 h-px bg-border" />
                     <button

--- a/open-dupr-react/src/components/Login.css
+++ b/open-dupr-react/src/components/Login.css
@@ -10,6 +10,11 @@
     "Ubuntu", "Cantarell", sans-serif;
 }
 
+/* Dark mode background gradient */
+.dark .login-container {
+  background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+}
+
 /* Login Card - Modern card design */
 .login-card {
   background: white;
@@ -23,6 +28,13 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 2rem;
+}
+
+/* Dark mode card styles */
+.dark .login-card {
+  background: oklch(0.208 0.042 265.755);
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4),
+    0 10px 10px -5px rgba(0, 0, 0, 0.2);
 }
 
 .login-card:hover {
@@ -43,11 +55,19 @@
   letter-spacing: -0.025em;
 }
 
+.dark .login-title {
+  color: oklch(0.984 0.003 247.858);
+}
+
 .login-subtitle {
   color: #6b7280;
   font-size: 1rem;
   margin: 0;
   font-weight: 400;
+}
+
+.dark .login-subtitle {
+  color: oklch(0.704 0.04 256.788);
 }
 
 /* Form Styles */
@@ -70,6 +90,10 @@
   margin: 0;
 }
 
+.dark .form-label {
+  color: oklch(0.984 0.003 247.858);
+}
+
 .form-input {
   padding: 0.875rem 1rem;
   border: 2px solid #e5e7eb;
@@ -79,6 +103,13 @@
   background-color: #ffffff;
   width: 100%;
   box-sizing: border-box;
+  color: #1f2937;
+}
+
+.dark .form-input {
+  background-color: oklch(0.279 0.041 260.031);
+  border-color: oklch(1 0 0 / 10%);
+  color: oklch(0.984 0.003 247.858);
 }
 
 .form-input:focus {
@@ -87,8 +118,17 @@
   box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
 }
 
+.dark .form-input:focus {
+  border-color: oklch(0.58 0.19 263.86);
+  box-shadow: 0 0 0 3px oklch(0.58 0.19 263.86 / 0.1);
+}
+
 .form-input::placeholder {
   color: #9ca3af;
+}
+
+.dark .form-input::placeholder {
+  color: oklch(0.704 0.04 256.788);
 }
 
 /* Error Message */
@@ -100,6 +140,12 @@
   border-radius: 8px;
   font-size: 0.875rem;
   font-weight: 500;
+}
+
+.dark .error-message {
+  background-color: oklch(0.704 0.191 22.216 / 0.1);
+  border-color: oklch(0.704 0.191 22.216 / 0.3);
+  color: oklch(0.704 0.191 22.216);
 }
 
 /* Login Button */
@@ -144,10 +190,18 @@
   border-top: 1px solid #e5e7eb;
 }
 
+.dark .login-footer {
+  border-top-color: oklch(1 0 0 / 10%);
+}
+
 .login-footer p {
   color: #6b7280;
   font-size: 0.875rem;
   margin: 0;
+}
+
+.dark .login-footer p {
+  color: oklch(0.704 0.04 256.788);
 }
 
 .signup-link {

--- a/open-dupr-react/src/lib/theme-context-definition.ts
+++ b/open-dupr-react/src/lib/theme-context-definition.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import type { ThemeContextType } from './theme-types';
+
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);

--- a/open-dupr-react/src/lib/theme-context.tsx
+++ b/open-dupr-react/src/lib/theme-context.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import type { Theme } from './theme-types';
+import { ThemeContext } from './theme-context-definition';
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({
+  children,
+  defaultTheme = 'system',
+}) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem('theme') as Theme;
+    return stored || defaultTheme;
+  });
+
+  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    
+    const updateTheme = () => {
+      let newResolvedTheme: 'light' | 'dark';
+      
+      if (theme === 'system') {
+        newResolvedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light';
+      } else {
+        newResolvedTheme = theme;
+      }
+      
+      setResolvedTheme(newResolvedTheme);
+      
+      root.classList.remove('light', 'dark');
+      root.classList.add(newResolvedTheme);
+    };
+
+    updateTheme();
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = () => {
+      if (theme === 'system') {
+        updateTheme();
+      }
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, [theme]);
+
+  const handleSetTheme = (newTheme: Theme) => {
+    setTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+  };
+
+  return (
+    <ThemeContext.Provider
+      value={{
+        theme,
+        setTheme: handleSetTheme,
+        resolvedTheme,
+      }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/open-dupr-react/src/lib/theme-types.ts
+++ b/open-dupr-react/src/lib/theme-types.ts
@@ -1,0 +1,7 @@
+export type Theme = 'light' | 'dark' | 'system';
+
+export interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  resolvedTheme: 'light' | 'dark';
+}

--- a/open-dupr-react/src/lib/useTheme.ts
+++ b/open-dupr-react/src/lib/useTheme.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { ThemeContext } from './theme-context-definition';
+import type { ThemeContextType } from './theme-types';
+
+export const useTheme = (): ThemeContextType => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/open-dupr-react/src/main.tsx
+++ b/open-dupr-react/src/main.tsx
@@ -6,6 +6,7 @@ import "./index.css";
 import { AuthProvider } from "./lib/AuthProvider.tsx";
 import { LoadingProvider } from "./lib/loading-context.tsx";
 import { HeaderProvider } from "./lib/header-context.tsx";
+import { ThemeProvider } from "./lib/theme-context.tsx";
 import LoginPage from "./components/pages/Login.tsx";
 import AboutPage from "./components/pages/AboutPage.tsx";
 import ProfilePage from "./components/pages/ProfilePage.tsx";
@@ -22,10 +23,11 @@ import MatchDetailsPage from "./components/pages/MatchDetailsPage.tsx";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <AuthProvider>
-      <LoadingProvider>
-        <HeaderProvider>
-          <Router>
+    <ThemeProvider>
+      <AuthProvider>
+        <LoadingProvider>
+          <HeaderProvider>
+            <Router>
             <Routes>
               <Route path="/" element={<App />} />
               <Route path="/login" element={<LoginPage />} />
@@ -117,5 +119,6 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         </HeaderProvider>
       </LoadingProvider>
     </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
Add dark mode support with system preference detection and a user-override toggle in the hamburger menu.

This PR introduces a `ThemeProvider` to manage 'light', 'dark', and 'system' themes, persisting user preferences in local storage. The theme can be toggled via a new option in the `AppHeader`'s hamburger menu, and the login page has been updated with corresponding dark mode styles.

---
<a href="https://cursor.com/background-agent?bcId=bc-c23ed9ca-527d-4473-a81d-15d7e2bc66a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c23ed9ca-527d-4473-a81d-15d7e2bc66a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

