### PR TITLE
Add analytics script to head

### DIFF
--- a/open-dupr-react/index.html
+++ b/open-dupr-react/index.html
@@ -26,6 +26,7 @@
       } catch (_) { }
     })();
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="b3dae87a-5529-472d-a69f-d23a1d7f4daa"></script>
 </head>
 
 <body>

--- a/open-dupr-react/src/components/pages/AboutPage.tsx
+++ b/open-dupr-react/src/components/pages/AboutPage.tsx
@@ -83,6 +83,15 @@ export default function AboutPage() {
               </div>
 
               <div>
+                <h3 className="text-lg font-semibold mb-1">Analytics and Privacy</h3>
+                <p className="text-muted-foreground text-sm">
+                  This application uses Umami analytics to understand usage patterns and improve the user experience. 
+                  Umami is a privacy-focused analytics tool that does not use cookies or collect personal information. 
+                  The analytics are anonymous and help us understand how the application is being used.
+                </p>
+              </div>
+
+              <div>
                 <h3 className="text-lg font-semibold mb-1">
                   Is Open DUPR open source?
                 </h3>


### PR DESCRIPTION
Add Umami analytics script to `index.html` to track website usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd50a1e9-349c-476a-8bf4-cbce22c89346">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd50a1e9-349c-476a-8bf4-cbce22c89346">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

