### PR TITLE
Make analytics public on about page

### DIFF
--- a/open-dupr-react/src/components/pages/AboutPage.tsx
+++ b/open-dupr-react/src/components/pages/AboutPage.tsx
@@ -89,6 +89,18 @@ export default function AboutPage() {
                   Umami is a privacy-focused analytics tool that does not use cookies or collect personal information. 
                   The analytics are anonymous and help us understand how the application is being used.
                 </p>
+                <p className="text-muted-foreground text-sm">
+                  Analytics are publicly available for anyone to view. See the
+                  <a
+                    href="https://cloud.umami.is/share/hd9kfrVkKVc4YoWf/opendupr.com"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline ml-1"
+                  >
+                    Open DUPR analytics dashboard
+                  </a>
+                  .
+                </p>
               </div>
 
               <div>
@@ -134,6 +146,19 @@ export default function AboutPage() {
             >
               <ExternalLink className="h-4 w-4" />
               Official DUPR
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() =>
+                window.open(
+                  "https://cloud.umami.is/share/hd9kfrVkKVc4YoWf/opendupr.com",
+                  "_blank",
+                )
+              }
+              className="flex items-center gap-2"
+            >
+              <ExternalLink className="h-4 w-4" />
+              View Analytics
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Add a link and button to the public Umami analytics dashboard on the About page to make analytics publicly accessible.

---
<a href="https://cursor.com/background-agent?bcId=bc-2dba930d-9795-4c96-866a-d35ffb736f8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2dba930d-9795-4c96-866a-d35ffb736f8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

