### PR TITLE
Fix missing rating changes on feed match details

### DIFF
--- a/open-dupr-react/src/components/pages/FeedPage.tsx
+++ b/open-dupr-react/src/components/pages/FeedPage.tsx
@@ -136,6 +136,7 @@ function transformFeedMatch(feedMatch: FeedMatch): Match {
           game3: team.game3,
           game4: team.game4,
           game5: team.game5,
+          preMatchRatingAndImpact: team.preMatchRatingAndImpact as Record<string, string | number | null | undefined> | undefined,
         })
       ),
     confirmed: feedMatch.confirmed,


### PR DESCRIPTION
Add `preMatchRatingAndImpact` to `transformFeedMatch` to display rating changes on match details from the feed page.

The `transformFeedMatch` function in `FeedPage.tsx` was not mapping the `preMatchRatingAndImpact` field from the feed data to the transformed match object, causing rating changes to be missing from feed-originated match details. This change ensures consistency with match details accessed from the profile history.

---
<a href="https://cursor.com/background-agent?bcId=bc-75004cf8-1655-472a-b198-2c2724f2a877">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75004cf8-1655-472a-b198-2c2724f2a877">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

