### PR TITLE
Show only singles or doubles rating

### DIFF
--- a/open-dupr-react/src/components/pages/FollowersFollowingPage.tsx
+++ b/open-dupr-react/src/components/pages/FollowersFollowingPage.tsx
@@ -695,18 +695,36 @@ const FollowersFollowingPage: React.FC = () => {
                       {user.name?.trim().replace(/\s+/g, " ")}
                     </p>
                     <div className="flex gap-3 text-sm text-muted-foreground">
-                      <div className="flex items-center gap-1">
-                        <User className="h-3 w-3" />
-                        <span className="font-mono font-medium">
-                          {userRatings[user.id]?.singles || "-"}
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <Users className="h-3 w-3" />
-                        <span className="font-mono font-medium">
-                          {userRatings[user.id]?.doubles || "-"}
-                        </span>
-                      </div>
+                      {sortOption === "doubles" ? (
+                        <div className="flex items-center gap-1">
+                          <Users className="h-3 w-3" />
+                          <span className="font-mono font-medium">
+                            {userRatings[user.id]?.doubles || "-"}
+                          </span>
+                        </div>
+                      ) : sortOption === "singles" ? (
+                        <div className="flex items-center gap-1">
+                          <User className="h-3 w-3" />
+                          <span className="font-mono font-medium">
+                            {userRatings[user.id]?.singles || "-"}
+                          </span>
+                        </div>
+                      ) : (
+                        <>
+                          <div className="flex items-center gap-1">
+                            <User className="h-3 w-3" />
+                            <span className="font-mono font-medium">
+                              {userRatings[user.id]?.singles || "-"}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Users className="h-3 w-3" />
+                            <span className="font-mono font-medium">
+                              {userRatings[user.id]?.doubles || "-"}
+                            </span>
+                          </div>
+                        </>
+                      )}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Modify the follow list to only display the relevant singles or doubles rating when sorted by that specific rating type.

---
<a href="https://cursor.com/background-agent?bcId=bc-745a51df-dc1b-4f86-b25b-7536eb4fa467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-745a51df-dc1b-4f86-b25b-7536eb4fa467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

