### PR TITLE
Slow down aggressive site refresh

### DIFF
--- a/open-dupr-react/src/components/ui/pull-to-refresh.tsx
+++ b/open-dupr-react/src/components/ui/pull-to-refresh.tsx
@@ -2,18 +2,18 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
 // Track recent successful pull-to-refresh triggers across the app.
-// If 3 triggers occur within 15 seconds, perform a hard reload.
+// If 5 triggers occur within 60 seconds, perform a hard reload.
 let pullToRefreshTimestamps: number[] = [];
-const PULL_TO_REFRESH_WINDOW_MS = 15000;
+const PULL_TO_REFRESH_WINDOW_MS = 60000;
 
 function recordPullAndShouldHardReload(): boolean {
   const now = Date.now();
-  // Keep only timestamps within the last 15 seconds
+  // Keep only timestamps within the last 60 seconds
   pullToRefreshTimestamps = pullToRefreshTimestamps.filter(
     (t) => now - t <= PULL_TO_REFRESH_WINDOW_MS
   );
   pullToRefreshTimestamps.push(now);
-  if (pullToRefreshTimestamps.length >= 3) {
+  if (pullToRefreshTimestamps.length >= 5) {
     pullToRefreshTimestamps = [];
     return true;
   }

--- a/open-dupr-react/src/components/ui/pull-to-refresh.tsx
+++ b/open-dupr-react/src/components/ui/pull-to-refresh.tsx
@@ -2,18 +2,18 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
 // Track recent successful pull-to-refresh triggers across the app.
-// If 5 triggers occur within 60 seconds, perform a hard reload.
+// If 3 triggers occur within 15 seconds, perform a hard reload.
 let pullToRefreshTimestamps: number[] = [];
-const PULL_TO_REFRESH_WINDOW_MS = 60000;
+const PULL_TO_REFRESH_WINDOW_MS = 15000;
 
 function recordPullAndShouldHardReload(): boolean {
   const now = Date.now();
-  // Keep only timestamps within the last 60 seconds
+  // Keep only timestamps within the last 15 seconds
   pullToRefreshTimestamps = pullToRefreshTimestamps.filter(
     (t) => now - t <= PULL_TO_REFRESH_WINDOW_MS
   );
   pullToRefreshTimestamps.push(now);
-  if (pullToRefreshTimestamps.length >= 5) {
+  if (pullToRefreshTimestamps.length >= 3) {
     pullToRefreshTimestamps = [];
     return true;
   }

--- a/open-dupr-react/src/main.tsx
+++ b/open-dupr-react/src/main.tsx
@@ -156,11 +156,11 @@ if (typeof window !== "undefined" && "serviceWorker" in navigator) {
     immediate: true,
     onRegistered(registration) {
       if (!registration) return;
-      const HOUR = 60 * 60 * 1000;
+      const FOUR_HOURS = 4 * 60 * 60 * 1000;
       // Periodically check for updates
       setInterval(() => {
         registration.update().catch(() => {});
-      }, HOUR);
+      }, FOUR_HOURS);
       // Check for updates when app becomes visible
       document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "visible") {

--- a/open-dupr-react/src/main.tsx
+++ b/open-dupr-react/src/main.tsx
@@ -156,11 +156,11 @@ if (typeof window !== "undefined" && "serviceWorker" in navigator) {
     immediate: true,
     onRegistered(registration) {
       if (!registration) return;
-      const FOUR_HOURS = 4 * 60 * 60 * 1000;
+      const ONE_DAY = 24 * 60 * 60 * 1000;
       // Periodically check for updates
       setInterval(() => {
         registration.update().catch(() => {});
-      }, FOUR_HOURS);
+      }, ONE_DAY);
       // Check for updates when app becomes visible
       document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "visible") {


### PR DESCRIPTION
Slow down aggressive site refresh mechanisms by increasing pull-to-refresh hard reload thresholds and service worker update intervals.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6699171-5c9a-463f-866f-500139ca3699">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6699171-5c9a-463f-866f-500139ca3699">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

