### PR TITLE
Prevent redundant filter selection

### DIFF
--- a/open-dupr-react/src/components/player/MatchHistory.tsx
+++ b/open-dupr-react/src/components/player/MatchHistory.tsx
@@ -147,6 +147,10 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({
   );
 
   const handleFilterChange = useCallback((newFilter: string) => {
+    if (newFilter === activeFilter) {
+      setShowFilterDropdown(false);
+      return;
+    }
     setActiveFilter(newFilter);
     setMatches([]);
     setOffset(0);
@@ -154,7 +158,7 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({
     setTotalCount(null);
     setError(null);
     setShowFilterDropdown(false);
-  }, []);
+  }, [activeFilter]);
 
   const toggleFilterDropdown = useCallback(() => {
     if (!showFilterDropdown && buttonRef.current) {
@@ -343,30 +347,30 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({
           >
             <div className="p-2">
               <button
-                className={`w-full text-left px-3 py-2 text-sm rounded-sm hover:bg-accent hover:text-accent-foreground ${
+                className={`w-full text-left px-3 py-2 text-sm rounded-sm transition-colors ${
                   activeFilter === "all"
-                    ? "bg-accent text-accent-foreground"
-                    : ""
+                    ? "bg-primary text-primary-foreground font-medium"
+                    : "hover:bg-accent hover:text-accent-foreground"
                 }`}
                 onClick={() => handleFilterChange("all")}
               >
                 All Matches
               </button>
               <button
-                className={`w-full text-left px-3 py-2 text-sm rounded-sm hover:bg-accent hover:text-accent-foreground ${
+                className={`w-full text-left px-3 py-2 text-sm rounded-sm transition-colors ${
                   activeFilter === "singles"
-                    ? "bg-accent text-accent-foreground"
-                    : ""
+                    ? "bg-primary text-primary-foreground font-medium"
+                    : "hover:bg-accent hover:text-accent-foreground"
                 }`}
                 onClick={() => handleFilterChange("singles")}
               >
                 Singles Only
               </button>
               <button
-                className={`w-full text-left px-3 py-2 text-sm rounded-sm hover:bg-accent hover:text-accent-foreground ${
+                className={`w-full text-left px-3 py-2 text-sm rounded-sm transition-colors ${
                   activeFilter === "doubles"
-                    ? "bg-accent text-accent-foreground"
-                    : ""
+                    ? "bg-primary text-primary-foreground font-medium"
+                    : "hover:bg-accent hover:text-accent-foreground"
                 }`}
                 onClick={() => handleFilterChange("doubles")}
               >


### PR DESCRIPTION
Fix filter behavior to prevent reloads on active selection and improve selected item contrast.

Previously, clicking an already selected filter option would trigger a data reload, causing a temporary "no matches" display. This change ensures that clicking an active filter simply closes the dropdown without initiating a new search.

---
<a href="https://cursor.com/background-agent?bcId=bc-5530d6b5-60ed-49c2-a6fc-6cdbb097d6c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5530d6b5-60ed-49c2-a6fc-6cdbb097d6c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

