### PR TITLE
Animate profile rating increments on load

### DIFF
--- a/open-dupr-react/src/components/player/PlayerStatsRatings.tsx
+++ b/open-dupr-react/src/components/player/PlayerStatsRatings.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import ReliabilityModal from "@/components/ui/reliability-modal";
 import { PlayerStatsSkeleton } from "@/components/ui/loading-skeletons";
+import AnimatedCounter from "@/components/ui/animated-counter";
 import type { UserStats } from "@/lib/types";
 import RatingHistoryChart from "./RatingHistoryChart";
 
@@ -16,13 +17,26 @@ interface PlayerStatsRatingsProps {
   doublesReliabilityScore?: number;
 }
 
-const formatRating = (value: unknown): string => {
-  if (value == null) return "-";
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value.toFixed(3) : "-";
+const AnimatedRating: React.FC<{ value: unknown; className?: string }> = ({
+  value,
+  className = "",
+}) => {
+  if (value == null) return <span className={className}>-</span>;
+  
+  const numericValue = typeof value === "number" ? value : Number(value);
+  
+  if (!Number.isFinite(numericValue)) {
+    return <span className={className}>-</span>;
   }
-  const text = String(value).trim();
-  return text.length > 0 ? text : "-";
+
+  return (
+    <AnimatedCounter
+      value={numericValue}
+      duration={1500}
+      decimals={3}
+      className={className}
+    />
+  );
 };
 
 const formatReliability = (score?: number): string => {
@@ -227,7 +241,7 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
           <div className="text-center">
             <div className="grid grid-cols-2 gap-3 mt-1.5">
               <div>
-                <p className="text-2xl font-bold">{formatRating(singles)}</p>
+                <AnimatedRating value={singles} className="text-2xl font-bold" />
                 <p className="text-xs text-muted-foreground">Singles</p>
                 {singlesReliabilityScore != null && (
                   <p className="text-xs text-[color:var(--success)] font-medium">
@@ -236,7 +250,7 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
                 )}
               </div>
               <div>
-                <p className="text-2xl font-bold">{formatRating(doubles)}</p>
+                <AnimatedRating value={doubles} className="text-2xl font-bold" />
                 <p className="text-xs text-muted-foreground">Doubles</p>
                 {doublesReliabilityScore != null && (
                   <p className="text-xs text-[color:var(--success)] font-medium">
@@ -267,7 +281,7 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
           <div className="text-center lg:text-left">
             <div className="grid grid-cols-2 gap-3 mt-1.5 lg:mt-0 lg:max-w-xs">
               <div>
-                <p className="text-2xl font-bold">{formatRating(singles)}</p>
+                <AnimatedRating value={singles} className="text-2xl font-bold" />
                 <p className="text-xs text-muted-foreground">Singles</p>
                 {singlesReliabilityScore != null && (
                   <div className="flex items-center justify-center lg:justify-start gap-1">
@@ -288,7 +302,7 @@ const PlayerStatsRatings: React.FC<PlayerStatsRatingsProps> = ({
                 )}
               </div>
               <div className="lg:justify-self-end">
-                <p className="text-2xl font-bold">{formatRating(doubles)}</p>
+                <AnimatedRating value={doubles} className="text-2xl font-bold" />
                 <p className="text-xs text-muted-foreground">Doubles</p>
                 {doublesReliabilityScore != null && (
                   <div className="flex items-center justify-center lg:justify-start gap-1">

--- a/open-dupr-react/src/components/ui/animated-counter.tsx
+++ b/open-dupr-react/src/components/ui/animated-counter.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from "react";
+
+interface AnimatedCounterProps {
+  value: number;
+  duration?: number;
+  decimals?: number;
+  className?: string;
+}
+
+const AnimatedCounter: React.FC<AnimatedCounterProps> = ({
+  value,
+  duration = 1500,
+  decimals = 3,
+  className = "",
+}) => {
+  const [displayValue, setDisplayValue] = useState(0);
+
+  useEffect(() => {
+    if (!Number.isFinite(value) || value === 0) {
+      setDisplayValue(value);
+      return;
+    }
+
+    let startTime: number | null = null;
+    let animationFrame: number;
+
+    const animate = (timestamp: number) => {
+      if (startTime === null) {
+        startTime = timestamp;
+      }
+
+      const progress = Math.min((timestamp - startTime) / duration, 1);
+      
+      // Ease-in-out cubic function
+      const easeInOutCubic = (t: number): number => {
+        return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+      };
+
+      const easedProgress = easeInOutCubic(progress);
+      const currentValue = value * easedProgress;
+
+      setDisplayValue(currentValue);
+
+      if (progress < 1) {
+        animationFrame = requestAnimationFrame(animate);
+      }
+    };
+
+    animationFrame = requestAnimationFrame(animate);
+
+    return () => {
+      if (animationFrame) {
+        cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [value, duration]);
+
+  const formatValue = (val: number): string => {
+    if (!Number.isFinite(val)) return "-";
+    return val.toFixed(decimals);
+  };
+
+  return <span className={className}>{formatValue(displayValue)}</span>;
+};
+
+export default AnimatedCounter;


### PR DESCRIPTION
Add an animated counter for player ratings to smoothly increment from 0 to their actual value on profile load, enhancing user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd5a48de-198c-490f-b28a-eb3a2563f96c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd5a48de-198c-490f-b28a-eb3a2563f96c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

