### PR TITLE
Fix match card skeleton feed sizing

### DIFF
--- a/open-dupr-react/src/components/ui/loading-skeletons.tsx
+++ b/open-dupr-react/src/components/ui/loading-skeletons.tsx
@@ -50,50 +50,24 @@ export const PlayerProfileSkeleton: React.FC = () => (
 );
 
 export const MatchCardSkeleton: React.FC = () => (
-  <Card className="p-3 cursor-pointer transition-colors hover:bg-accent/50">
-    <CardContent className="p-0">
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-5 w-12 rounded" />
-            <Skeleton className="h-3 w-14" />
-          </div>
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-3 w-16" />
-          </div>
+  <Card className="p-4">
+    <CardContent className="p-0 space-y-4">
+      <div className="flex justify-between items-center">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-4 w-16" />
+      </div>
+      
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-10 w-10 rounded-full" />
+          <Skeleton className="h-5 w-32" />
         </div>
-        <div className="flex flex-col gap-2 md:grid md:grid-cols-[1fr_auto_1fr] md:items-center">
-          <div className="min-w-0 md:justify-self-start">
-            <div className="flex items-center gap-2 min-w-0">
-              <div className="flex -space-x-2">
-                <Skeleton className="h-8 w-8 rounded-full" />
-                <Skeleton className="h-8 w-8 rounded-full" />
-              </div>
-              <div className="min-w-0">
-                <div className="flex flex-col gap-1">
-                  <Skeleton className="h-3.5 w-24" />
-                  <Skeleton className="h-3.5 w-28" />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="flex flex-col items-center justify-center gap-1">
-            <Skeleton className="h-16 w-20" />
-          </div>
-          <div className="min-w-0 self-end md:justify-self-end">
-            <div className="flex items-center gap-2 min-w-0">
-              <div className="flex -space-x-2">
-                <Skeleton className="h-8 w-8 rounded-full" />
-                <Skeleton className="h-8 w-8 rounded-full" />
-              </div>
-              <div className="min-w-0">
-                <div className="flex flex-col gap-1">
-                  <Skeleton className="h-3.5 w-20" />
-                  <Skeleton className="h-3.5 w-24" />
-                </div>
-              </div>
-            </div>
-          </div>
+        
+        <Skeleton className="h-8 w-12" />
+        
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-5 w-28" />
+          <Skeleton className="h-10 w-10 rounded-full" />
         </div>
       </div>
     </CardContent>


### PR DESCRIPTION
Update `MatchCardSkeleton` to precisely match the layout and sizing of the `MatchCard` component.

The previous `MatchCardSkeleton` had significant discrepancies in padding, internal layout (flex/grid structure, spacing), and content representation compared to the actual `MatchCard`. This PR aligns the skeleton's visual properties, such as card padding, `CardContent` padding, and the overall responsive layout, to provide a more accurate and consistent loading state for users.

---
<a href="https://cursor.com/background-agent?bcId=bc-1cc9fe0f-e6e9-4138-9fdf-ef694dda53d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1cc9fe0f-e6e9-4138-9fdf-ef694dda53d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

