### PR TITLE
Animate match loading for perceived speed

### DIFF
--- a/open-dupr-react/src/components/player/MatchHistory.tsx
+++ b/open-dupr-react/src/components/player/MatchHistory.tsx
@@ -74,6 +74,7 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({
   const [hasLoadedOnce, setHasLoadedOnce] = useState<boolean>(false);
   const loaderRef = useRef<HTMLDivElement | null>(null);
   const spinnerTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const hasLoadedOnceRef = useRef<boolean>(false);
   const PAGE_SIZE = 25;
 
   // Get current logged-in user's ID
@@ -98,7 +99,7 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({
         setIsLoadingMore(true);
 
         // Show spinner after 150ms if still loading (for perceived speed)
-        if (startOffset === 0 && !hasLoadedOnce) {
+        if (startOffset === 0 && !hasLoadedOnceRef.current) {
           spinnerTimeoutRef.current = setTimeout(() => {
             setShowSpinner(true);
           }, 150);
@@ -140,6 +141,7 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({
         
         if (startOffset === 0) {
           setHasLoadedOnce(true);
+          hasLoadedOnceRef.current = true;
         }
       } catch (err) {
         setError(
@@ -155,7 +157,7 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({
         setShowSpinner(false);
       }
     },
-    [activeFilter, hasLoadedOnce]
+    [activeFilter]
   );
 
   const handleFilterChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -170,6 +172,7 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({
     setTotalCount(null);
     setError(null);
     setHasLoadedOnce(false);
+    hasLoadedOnceRef.current = false;
     setShowSpinner(false);
     if (spinnerTimeoutRef.current) {
       clearTimeout(spinnerTimeoutRef.current);
@@ -189,6 +192,7 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({
         setHasMore(true);
         setTotalCount(null);
         setHasLoadedOnce(false);
+        hasLoadedOnceRef.current = false;
         setShowSpinner(false);
         if (spinnerTimeoutRef.current) {
           clearTimeout(spinnerTimeoutRef.current);


### PR DESCRIPTION
Add a loading spinner and slide-up animations to match history on profile pages to improve perceived loading speed.

A loading spinner now appears after a short delay (150ms) if data is still loading, ensuring instant results on fast connections. Both match cards and skeleton loaders animate sliding up, providing continuous visual feedback and a smoother user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf07532a-4200-4b3e-bf7e-4530beb1607f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf07532a-4200-4b3e-bf7e-4530beb1607f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

