### PR TITLE
Increase spacing above match history details

### DIFF
--- a/open-dupr-react/src/components/player/MatchHistory.tsx
+++ b/open-dupr-react/src/components/player/MatchHistory.tsx
@@ -215,7 +215,7 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({
       <div className="flex items-center justify-between gap-3">
         <div className="flex flex-col">
           <h2 className="text-xl font-bold">Match History</h2>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 mt-4">
             <select
               value={activeFilter}
               onChange={handleFilterChange}


### PR DESCRIPTION
Increase spacing between the "Match History" heading and the filter controls.

This improves visual separation and readability by adding `mt-4` (margin-top: 1rem) to the div containing the filter dropdown and match count text.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2350e6c-80b0-40e8-9550-53fd3163e05e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2350e6c-80b0-40e8-9550-53fd3163e05e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

